### PR TITLE
Switch to Node.js env

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This plugin allows you to search for projects and deployments. I's based on Vercel Raycast Extension.
 
-## Requirements
+## Installation
 
-To run this plugin you need to have Node.js installed. You can download a portable zip version of Node.js at https://nodejs.org/en/download/current/, then set the path to the portable Node.js in node.bat
-
-The modules used in this plugin are kept in the node_modules folder.
+This plugin can be found in Flow Launcher's plugin store, or alternatively from Flow type `pm install Vercel`

--- a/plugin.json
+++ b/plugin.json
@@ -4,9 +4,9 @@
   "Name": "Vercel",
   "Description": "View your Vercel projects and deployments.",
   "Author": "Guilherme S. Sousa (@krteazy)",
-  "Version": "1.0.0",
-  "Language": "executable",
+  "Version": "1.0.1",
+  "Language": "typescript",
   "Website": "https://github.com/guilherssousa/flow-launcher-vercel-plugin",
-  "ExecuteFileName": "run.bat",
+  "ExecuteFileName": "./build/index.js",
   "IcoPath": "icon.png"
 }

--- a/run.bat
+++ b/run.bat
@@ -1,3 +1,0 @@
-@echo off
-SET plugin_dir=%~dp0%
-node "%plugin_dir%/build/index.js" %*


### PR DESCRIPTION
Hi there, this PR will switch the plugin to use Flow's automatic Node.js environment setup. User will be prompted to install/select Node.js, so manual installation will no longer be required.